### PR TITLE
 Fix: Updated broken link in Jump Start with Microcks

### DIFF
--- a/frontend/src/app/components/footer-bar/footer-bar.component.html
+++ b/frontend/src/app/components/footer-bar/footer-bar.component.html
@@ -10,7 +10,7 @@
         <div class="mh-footer-bar-contents-left_text">
           Microcks is an open source Kubernetes native platform for mocking APIs and microservices, allowing contract testing in an automated and scalable way.
         </div>
-        <a class="mh-footer-bar_button" href="https://microcks.io/documentation/getting-started/">Jump-start with Microcks</a>
+        <a class="mh-footer-bar_button" href="https://microcks.io/documentation/tutorials/getting-started/">Get Started with Microcks</a>
       </div>
       <div class="mh-footer-bar-contents-right">
         <img class="mh-footer-bar-contents-right_logo" src="/assets/images/hub-microcks.svg" alt="Microcks">


### PR DESCRIPTION
## Related Issue
- Fixes *#83*.

##  Changes Made  
- Updated the incorrect link for **"Jump Start with Microcks"** that was redirecting to a non-existent (404) page.  
- Replaced it with the correct URL: [Getting Started - Microcks](https://microcks.io/documentation/tutorials/getting-started/).  
- **Text Change:**  
  - **Before:** `Jump-start with Microcks`  
  - **After:** `Get Started with Microcks`  
- **Code Change:**  
  ```html
  <!-- Before -->
  <a class="mh-footer-bar_button" href="https://microcks.io/documentation/getting-started/">Jump-start with Microcks</a>

  <!-- After -->
  <a class="mh-footer-bar_button" href="https://microcks.io/documentation/tutorials/getting-started/">Get Started with Microcks</a>
