### PR TITLE
Fix: Updated Broken Privacy Policy Link in Footer

### DIFF
--- a/frontend/src/app/components/footer-bar/footer-bar.component.html
+++ b/frontend/src/app/components/footer-bar/footer-bar.component.html
@@ -19,8 +19,8 @@
             <h5 class="mh-footer-bar-contents-right_links_list_header">ABOUT</h5>
             <a class="mh-footer-bar-contents-right_links_list_link" href="https://microcks.io/" target="_blank" rel="noopener noreferrer">What is Microcks ?</a>
             <a class="mh-footer-bar-contents-right_links_list_link" href="https://microcks.io/blog/microcks-hub-announcement/" target="_blank" rel="noopener noreferrer">About Hub.microcks.io</a>
-            <a class="mh-external-link mh-footer-bar-contents-right_links_links_list_link" href="https://microcks.io/documentation/" target="_blank" rel="noopener noreferrer">Documentation</a>
-            <a class="mh-external-link mh-footer-bar-contents-right_links_links_list_link" href="https://microcks.io/about/privacy-policy" target="_blank" rel="noopener noreferrer">Privacy Policy</a>
+            <a class="mh-external-link mh-footer-bar-contents-right_links_links_list_link" href="https://microcks.io/documentation/getting-started/" target="_blank" rel="noopener noreferrer">Documentation</a>
+            <a class="mh-external-link mh-footer-bar-contents-right_links_links_list_link" href="https://www.linuxfoundation.org/legal/privacy-policy" target="_blank" rel="noopener noreferrer">Privacy Policy</a>
           </div>
           <div class="mh-footer-bar-contents-right_links_list">
             <h5 class="mh-footer-bar-contents-right_links_list_header">NETWORK</h5>

--- a/frontend/src/app/components/footer-bar/footer-bar.component.html
+++ b/frontend/src/app/components/footer-bar/footer-bar.component.html
@@ -10,7 +10,7 @@
         <div class="mh-footer-bar-contents-left_text">
           Microcks is an open source Kubernetes native platform for mocking APIs and microservices, allowing contract testing in an automated and scalable way.
         </div>
-        <a class="mh-footer-bar_button" href="https://microcks.io/documentation/tutorials/getting-started/">Get Started with Microcks</a>
+        <a class="mh-footer-bar_button" href="https://microcks.io/documentation/getting-started/">Jump-start with Microcks</a>
       </div>
       <div class="mh-footer-bar-contents-right">
         <img class="mh-footer-bar-contents-right_logo" src="/assets/images/hub-microcks.svg" alt="Microcks">
@@ -19,7 +19,7 @@
             <h5 class="mh-footer-bar-contents-right_links_list_header">ABOUT</h5>
             <a class="mh-footer-bar-contents-right_links_list_link" href="https://microcks.io/" target="_blank" rel="noopener noreferrer">What is Microcks ?</a>
             <a class="mh-footer-bar-contents-right_links_list_link" href="https://microcks.io/blog/microcks-hub-announcement/" target="_blank" rel="noopener noreferrer">About Hub.microcks.io</a>
-            <a class="mh-external-link mh-footer-bar-contents-right_links_links_list_link" href="https://microcks.io/documentation/getting-started/" target="_blank" rel="noopener noreferrer">Documentation</a>
+            <a class="mh-external-link mh-footer-bar-contents-right_links_links_list_link" href="https://microcks.io/documentation/" target="_blank" rel="noopener noreferrer">Documentation</a>
             <a class="mh-external-link mh-footer-bar-contents-right_links_links_list_link" href="https://microcks.io/about/privacy-policy" target="_blank" rel="noopener noreferrer">Privacy Policy</a>
           </div>
           <div class="mh-footer-bar-contents-right_links_list">

--- a/frontend/src/app/components/footer-bar/footer-bar.component.html
+++ b/frontend/src/app/components/footer-bar/footer-bar.component.html
@@ -10,7 +10,7 @@
         <div class="mh-footer-bar-contents-left_text">
           Microcks is an open source Kubernetes native platform for mocking APIs and microservices, allowing contract testing in an automated and scalable way.
         </div>
-        <a class="mh-footer-bar_button" href="https://microcks.io/documentation/getting-started/">Jump-start with Microcks</a>
+        <a class="mh-footer-bar_button" href="https://microcks.io/documentation/tutorials/getting-started/">Get Started with Microcks</a>
       </div>
       <div class="mh-footer-bar-contents-right">
         <img class="mh-footer-bar-contents-right_logo" src="/assets/images/hub-microcks.svg" alt="Microcks">


### PR DESCRIPTION
### **Description**  
Fixed the broken Privacy Policy link in the footer by updating it to the correct Linux Foundation page.  

## **Related Issue**  
- Fixes *#88*.  

### **Changes Made**  

**Previous Link (Broken):**  
https://microcks.io/about/privacy-policy  

**New Link (Fixed):**  
https://www.linuxfoundation.org/legal/privacy-policy