### PR TITLE
fix: documentaion broken link in footer

### DIFF
--- a/frontend/src/app/components/footer-bar/footer-bar.component.html
+++ b/frontend/src/app/components/footer-bar/footer-bar.component.html
@@ -19,7 +19,7 @@
             <h5 class="mh-footer-bar-contents-right_links_list_header">ABOUT</h5>
             <a class="mh-footer-bar-contents-right_links_list_link" href="https://microcks.io/" target="_blank" rel="noopener noreferrer">What is Microcks ?</a>
             <a class="mh-footer-bar-contents-right_links_list_link" href="https://microcks.io/blog/microcks-hub-announcement/" target="_blank" rel="noopener noreferrer">About Hub.microcks.io</a>
-            <a class="mh-external-link mh-footer-bar-contents-right_links_links_list_link" href="https://microcks.io/documentation/getting-started/" target="_blank" rel="noopener noreferrer">Documentation</a>
+            <a class="mh-external-link mh-footer-bar-contents-right_links_links_list_link" href="https://microcks.io/documentation/" target="_blank" rel="noopener noreferrer">Documentation</a>
             <a class="mh-external-link mh-footer-bar-contents-right_links_links_list_link" href="https://www.linuxfoundation.org/legal/privacy-policy" target="_blank" rel="noopener noreferrer">Privacy Policy</a>
           </div>
           <div class="mh-footer-bar-contents-right_links_list">


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

- Fixed broken link in footer navigation that was directing to `https://microcks.io/documentation/getting-started/`, resulting in a 404 error.
- Updated the footer link to the correct URL: `https://microcks.io/documentation/`.
- Ensured that the correct documentation page loads without a 404 error when the link is clicked.

### Related issue(s)

Fixes #86