### PR TITLE
allowing width attribute in markdownConverter

### DIFF
--- a/frontend/src/app/components/markdown.ts
+++ b/frontend/src/app/components/markdown.ts
@@ -59,7 +59,7 @@ export const markdownConverter = {
       allowedAttributes: {
         a: ['href', 'target', 'rel'],
         code: ['class'],
-        img: ['src', 'alt', 'title']
+        img: ['src', 'alt', 'title', 'width']
       },
       allowedSchemes: ['http', 'https', 'mailto'],
       transformTags: {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description
This PR allows the width attribute to be accessed from Yaml

### Related issue(s)
Resolves #119 

<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->