### PR TITLE
fix: correct broken documentation link in footer (#86)

### DIFF
--- a/frontend/src/app/components/footer-bar/footer-bar.component.html
+++ b/frontend/src/app/components/footer-bar/footer-bar.component.html
@@ -19,7 +19,7 @@
             <h5 class="mh-footer-bar-contents-right_links_list_header">ABOUT</h5>
             <a class="mh-footer-bar-contents-right_links_list_link" href="https://microcks.io/" target="_blank" rel="noopener noreferrer">What is Microcks ?</a>
             <a class="mh-footer-bar-contents-right_links_list_link" href="https://microcks.io/blog/microcks-hub-announcement/" target="_blank" rel="noopener noreferrer">About Hub.microcks.io</a>
-            <a class="mh-external-link mh-footer-bar-contents-right_links_links_list_link" href="https://microcks.io/documentation/getting-started/" target="_blank" rel="noopener noreferrer">Documentation</a>
+            <a class="mh-external-link mh-footer-bar-contents-right_links_links_list_link" href="https://microcks.io/documentation/tutorials/getting-started/" target="_blank" rel="noopener noreferrer">Documentation</a>
             <a class="mh-external-link mh-footer-bar-contents-right_links_links_list_link" href="https://www.linuxfoundation.org/legal/privacy-policy" target="_blank" rel="noopener noreferrer">Privacy Policy</a>
           </div>
           <div class="mh-footer-bar-contents-right_links_list">


### PR DESCRIPTION
### Description
- Fixed the broken Documentation link in the footer that was causing a 404 error.
- Updated the link to point to: https://microcks.io/documentation/tutorials/getting-started/

### Related issue(s)
Fixes (#86)