### PR TITLE
docs: Fix 404 links in create-api-mocks documentation (#125, #126)

### DIFF
--- a/server/documentation/create-api-mocks.md
+++ b/server/documentation/create-api-mocks.md
@@ -35,7 +35,7 @@ Although one artifact is enough for providing examples and a test suite, it may 
 * an OpenAPI specification for defining the syntactical contract of your API and examples,
 * an additional Postman collection for holding business related test assertions on your API - things that are typically impossible to represent using OpenAPI.
 
-It is definitely possible to reference multiple API artifacts in your contributed API package. Check out more detail on [Multi-artifacts support](https://microcks.io/documentation/using/importers/#multi-artifacts-support) documentation.
+It is definitely possible to reference multiple API artifacts in your contributed API package. Check out more detail on [Multi-artifacts support](https://microcks.io/documentation/explanations/multi-artifacts/) documentation.
 
 
 ## Share them!


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

- Fixed 404 link in **create-api-mocks documentation** referencing **supported formats**.  
- Fixed 404 link in **Multi-artifacts support** section under **create-api-mocks documentation**.  
- Updated the links to the correct references.

### Related issue(s)

Fixes #125  
Fixes #126  

<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->