### PR TITLE
docs: Fix 404 link in how-to-contribute documentation (#127)

### DIFF
--- a/server/documentation/how-to-contribute.md
+++ b/server/documentation/how-to-contribute.md
@@ -17,7 +17,7 @@ Have a look at some contributions in [https://github.com/microcks/community-mock
 
 ## Build your API package
 
-Basically, your API package is made of one or multiple API artifacts that live in their own repository. We encourage using a Git repository but the only requirement is to be a publicly available HTTP repository. By API artifacts, we mean any contract standard that is supported by Microcks - and [the list is now extensive](https://microcks.io/documentation/using/importers/#supported-formats) ; you probably already got them at hand!
+Basically, your API package is made of one or multiple API artifacts that live in their own repository. We encourage using a Git repository but the only requirement is to be a publicly available HTTP repository. By API artifacts, we mean any contract standard that is supported by Microcks - and [the list is now extensive](https://microcks.io/documentation/references/artifacts/) ; you probably already got them at hand!
 
 Check out more details on how to [create API mocks using supported formats](/doc/create-api-mocks).
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

- Fixed 404 link in **how-to-contribute documentation** referencing **supported formats**.  
- Updated the link to the correct reference.

### Related issue(s)

Fixes #127 

<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->