### PR TITLE
docs: Fix 404 link in package-api-mocks documentation (#132)

### DIFF
--- a/server/documentation/package-api-mocks.md
+++ b/server/documentation/package-api-mocks.md
@@ -1,6 +1,6 @@
 # How to describe API package and versions
 
-An API package is made of one or multiple API artifacts that live in their own repository. By API artifacts, we mean any contract standard that is supported by Microcks - and [the list is now extensive](https://microcks.io/documentation/using/importers/#supported-formats) ; you probably already got them at hand!
+An API package is made of one or multiple API artifacts that live in their own repository. By API artifacts, we mean any contract standard that is supported by Microcks - and [the list is now extensive](https://microcks.io/documentation/references/artifacts/) ; you probably already got them at hand!
 
 Check out more details on how to [create API mocks using supported formats](/doc/create-api-mocks).
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

- Fixed 404 link in **package-api-mocks documentation** referencing **supported formats**.  
- Updated the link to the correct reference.

### Related issue(s)

Fixes #132 
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->